### PR TITLE
CI: Use latest tag for main branch container images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=branch,enable=${{ github.ref != 'refs/heads/main' }}
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}


### PR DESCRIPTION
This PR updates the GitHub Actions workflow to tag container images built from the main branch as "latest" instead of "main".

Changes:
- Added a rule to tag images as "latest" when building from the main branch
- Modified the branch tagging rule to exclude the main branch (to avoid having both "main" and "latest" tags for the same image)

This will make it easier for users to reference the container image in their Docker or Kubernetes configurations, as they can use the standard "latest" tag convention.